### PR TITLE
fix: ビルドエラーの修正

### DIFF
--- a/packages/slackbot/package.json
+++ b/packages/slackbot/package.json
@@ -14,6 +14,9 @@
     "tsc": "tsc",
     "deploy:heroku": "yarn tsc && yarn start"
   },
+  "devDependencies": {
+    "typescript": "^4.3.4"
+  },
   "volta": {
     "node": "20.9.0",
     "yarn": "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7207,6 +7207,8 @@ __metadata:
 "slackbot@workspace:packages/slackbot":
   version: 0.0.0-use.local
   resolution: "slackbot@workspace:packages/slackbot"
+  dependencies:
+    typescript: "npm:^4.3.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
```
2025-04-22T17:54:44.531870+00:00 heroku[worker.1]: State changed from crashed to starting
2025-04-22T17:54:49.298715+00:00 heroku[worker.1]: Starting process with command `yarn deploy:heroku`
2025-04-22T17:54:49.865785+00:00 heroku[worker.1]: State changed from starting to up
2025-04-22T17:54:50.888031+00:00 app[worker.1]: command not found: tsc
2025-04-22T17:54:50.972348+00:00 heroku[worker.1]: Process exited with status 127
2025-04-22T17:54:50.998791+00:00 heroku[worker.1]: State changed from up to crashed
```