### PR TITLE
ci: yarn install が失敗する問題への対応

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: yarn deploy:heroku
+worker: NODE_OPTIONS=--max_old_space_size=1024 yarn && yarn deploy:bot


### PR DESCRIPTION
heroku の制限でメモリ超過が起きる