### PR TITLE
chore: Slack メッセージに fallback text を追加

### DIFF
--- a/src/slack/postMessage.ts
+++ b/src/slack/postMessage.ts
@@ -4,6 +4,35 @@ import { config } from '../config'
 
 const CHANNEL_ID = config.slack.channelId
 
+const collectFallbackTexts = (blocks: KnownBlock[]): string[] => {
+  return blocks.flatMap((block) => {
+    switch (block.type) {
+      case 'section':
+      case 'header':
+        return 'text' in block && block.text ? [block.text.text] : []
+      case 'context':
+        return block.elements.flatMap((element) =>
+          element.type === 'plain_text' || element.type === 'mrkdwn'
+            ? [element.text]
+            : [],
+        )
+      case 'image':
+        return block.alt_text ? [block.alt_text] : []
+      default:
+        return []
+    }
+  })
+}
+
+const createFallbackText = (blocks: KnownBlock[]): string => {
+  const text = collectFallbackTexts(blocks)
+    .map((value) => value.replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+    .join(' / ')
+
+  return text || 'Slack message'
+}
+
 export const postMessage = async ({
   client,
   blocks,
@@ -16,6 +45,7 @@ export const postMessage = async ({
   await client.chat.postMessage({
     ...options,
     channel: CHANNEL_ID,
+    text: options.text ?? createFallbackText(blocks),
     blocks,
   })
 }
@@ -32,6 +62,7 @@ export const postEphemeral = async ({
   await client.chat.postEphemeral({
     channel: CHANNEL_ID,
     user,
+    text: createFallbackText(blocks),
     blocks,
   })
 }


### PR DESCRIPTION
## 概要

Slack の `chat.postMessage` / `chat.postEphemeral` API では、`blocks` を使う際に `text` フィールドを省略すると通知文が空になる警告が出る。本PRでは、blocks の内容からフォールバック用テキストを自動生成して `text` に設定することで、この警告を解消する。

## 変更点

- `collectFallbackTexts`: blocks の各要素から表示テキストを収集するヘルパー関数を追加
- `createFallbackText`: 収集したテキストを結合してフォールバック文字列を生成する関数を追加
- `postMessage`: `options.text` が未指定の場合に `createFallbackText` の結果を使用するよう修正
- `postEphemeral`: 常に `createFallbackText` の結果を `text` に設定するよう修正

## 備考

`postMessage` は既存の呼び出し側が `text` を渡している場合はそちらを優先する (`options.text ?? ...`)。